### PR TITLE
Remove badassjs - not available anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Divided into the above listed categories...
   <li><a href="http://addyosmani.com/blog/feed">AddyOsmani.com | Articles for developers</a></li>
   <li><a href="http://appendto.com/feed/rss">AppendTo</a></li>
   <li><a href="http://feeds.feedburner.com/urn-rss20">UNSTOPPABLE ROBOT NINJA</a></li>
-  <li><a href="http://rss.badassjs.com">Badass JavaScript</a></li>
   <li><a href="http://googledevelopers.blogspot.com/feeds/posts/default?alt=rss">Google Developers Blog</a></li>
   <li><a href="http://feeds.feedburner.com/leaverou">Lea Verou</a></li>
   <li><a href="http://www.creativebloq.com/feed">Creative Bloq</a></li>


### PR DESCRIPTION
Hello! Thank you for providing this awesome list of feeds to follow.
badassjs has no RSS feed available anymore and the last post is from 2014.

Thank you in advance
