### PR TITLE
chore: remove a dead feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ These are large blogs/websites similar to the ones in the previous category that
   <li>[<a href="https://love2dev.com/feed.rss">RSS</a>] <a href="https://love2dev.com/">Love2Dev</a></li>
   <li>[<a href="https://www.nngroup.com/feed/rss/">RSS</a>] <a href="https://www.nngroup.com/articles">Nielsen Norman Group</a></li>
   <li>[<a href="https://developer.paciellogroup.com/feed/">RSS</a>] <a href="https://developer.paciellogroup.com">Paciello Group Blog</a></li>
-  <li>[<a href="https://scotch.io/feed">RSS</a>] <a href="https://scotch.io/">Scotch.io</a></li>
   <li>[<a href="https://www.sitepen.com/rss.xml">RSS</a>] <a href="https://www.sitepen.com">SitePen</a></li>
   <li>[<a href="https://feeds.telerik.com/blogs">RSS</a>] <a href="https://www.telerik.com/">Telerik</a></li>
   <li>[<a href="https://blog.teamtreehouse.com/feed">RSS</a>] <a href="https://blog.teamtreehouse.com">Treehouse Blog</a></li>

--- a/frontend-feeds.opml
+++ b/frontend-feeds.opml
@@ -41,7 +41,6 @@
       <outline type="rss" title="Love2Dev" text="Love2Dev" htmlUrl="https://love2dev.com/blog/" xmlUrl="https://love2dev.com/feed.rss"/>
       <outline type="rss" title="Nielsen Norman Group" text="Nielsen Norman Group" htmlUrl="https://www.nngroup.com/articles/" xmlUrl="https://www.nngroup.com/feed/rss/"/>
       <outline type="rss" title="Paciello Group Blog" text="Paciello Group Blog" htmlUrl="https://developer.paciellogroup.com/" xmlUrl="https://developer.paciellogroup.com/feed/"/>
-      <outline type="rss" title="Scotch.io" text="Scotch.io" htmlUrl="https://scotch.io/" xmlUrl="https://scotch.io/feed"/>
       <outline type="rss" title="SitePen" text="SitePen" htmlUrl="https://www.sitepen.com/blog/" xmlUrl="https://www.sitepen.com/feed/"/>
       <outline type="rss" title="Telerik" text="Telerik" htmlUrl="https://www.telerik.com/blogs" xmlUrl="https://feeds.telerik.com/blogs"/>
       <outline type="rss" title="Treehouse Blog" text="Treehouse Blog" htmlUrl="https://blog.teamtreehouse.com/" xmlUrl="https://blog.teamtreehouse.com/feed"/>
@@ -69,7 +68,7 @@
       <outline type="rss" title="Jeremy Keith (Articles)" text="Jeremy Keith (Articles)" htmlUrl="https://adactio.com/" xmlUrl="https://adactio.com/articles/rss"/>
       <outline type="rss" title="Jeremy Keith (Journal)" text="Jeremy Keith (Journal)" htmlUrl="https://adactio.com/" xmlUrl="https://adactio.com/journal/rss"/>
       <outline type="rss" title="Jonathan Snook" text="Jonathan Snook" htmlUrl="https://snook.ca/" xmlUrl="https://snook.ca/jonathan/index.rdf"/>
-      <outline type="rss" title="Kent C. Dodds" text="Kent C. Dodds" htmlUrl="https://kentcdodds.com/blog" xmlUrl="https://kentcdodds.com/blog/rss.xml"/>    
+      <outline type="rss" title="Kent C. Dodds" text="Kent C. Dodds" htmlUrl="https://kentcdodds.com/blog" xmlUrl="https://kentcdodds.com/blog/rss.xml"/>
       <outline type="rss" title="Lea Verou" text="Lea Verou" htmlUrl="https://lea.verou.me/" xmlUrl="https://lea.verou.me/feed/"/>
       <outline type="rss" title="Mark Otto" text="Mark Otto" htmlUrl="https://markdotto.com/" xmlUrl="https://markdotto.com/atom.xml"/>
       <outline type="rss" title="Mathias Bynens" text="Mathias Bynens" htmlUrl="https://mathiasbynens.be/" xmlUrl="https://mathiasbynens.be/notes.atom"/>


### PR DESCRIPTION
Scotch.io has been shut down, and when trying to access the page we are redirected to https://www.digitalocean.com/community. DO Community doesn't have an RSS feed as far as I know, so I went ahead and remove the dead feed.